### PR TITLE
Use SVOX repository at AOSP due to DMCA takedown

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -271,7 +271,7 @@
   <project path="external/stlport" name="CyanogenMod/android_external_stlport" groups="pdk" />
   <project path="external/strace" name="CyanogenMod/android_external_strace" />
   <project path="external/stressapptest" name="CyanogenMod/android_external_stressapptest" />
-  <project path="external/svox" name="CyanogenMod/android_external_svox" />
+  <project path="external/svox" name="platform/external/svox" remote="aosp" revision="refs/tags/android-4.4.4_r2" />
   <project path="external/tagsoup" name="CyanogenMod/android_external_tagsoup" />
   <project path="external/tcpdump" name="CyanogenMod/android_external_tcpdump" />
   <project path="external/timezonepicker-support" name="platform/external/timezonepicker-support" remote="aosp" revision="refs/tags/android-4.4.4_r2" />


### PR DESCRIPTION
 * Github got a DMCA takedown on this repo based on a licensing dispute with
   a former employee of SVOX. Already have enough drama in my life, just
   point this to Google as we don't make any changes here.

Change-Id: I78f36ed51fd875f5be10486429bc53091bab2860